### PR TITLE
Adding support for minlen and maxlen in API

### DIFF
--- a/uinames.com/api/index.php
+++ b/uinames.com/api/index.php
@@ -140,7 +140,10 @@ $amount   = isset($_GET['amount']) ? (int) $_GET['amount'] : 1;
 $country  = @$_GET['country'];
 $language = @$_GET['language'];
 $gender   = @$_GET['gender'];
+$minlen   = isset($_GET['minlen']) ? (int) $_GET['minlen'] : 1;
+$maxlen   = isset($_GET['maxlen']) ? (int) $_GET['maxlen'] : 1000;
 $results  = array();
+$count    = 0;
 
 function send ($content) { //, $code = 200) {
     $type = (!empty($_GET['callback'])) ? 'application/javascript' : 'application/json';
@@ -164,8 +167,14 @@ function send ($content) { //, $code = 200) {
 }
 
 try {
-    for ($i = 0; $i < $amount; $i++) {
-        $results[] = generate_name($database, $country, $language, $gender);
+    while ($count < $amount) {
+        $name = generate_name($database, $country, $language, $gender);
+        $name_length = iconv_strlen($name['name'] . ' ' . $name['surname']);
+        if ($name_length >= $minlen && $name_length <= $maxlen)
+        {
+            $results[] = $name;
+            $count++;
+        }
     }
 
     if (!isset($_GET['amount'])) {

--- a/uinames.com/index.php
+++ b/uinames.com/index.php
@@ -101,6 +101,10 @@
 			<br />
 			<p>Country specific results:</p>
 			<pre><span>http://api.uinames.com/</span>?country=germany</pre>
+			<p>Require a minimum number of characters in a name:</p>
+			<pre><span>http://api.uinames.com/</span>?minlen=25</pre>
+			<p>Require a maximum number of characters in a name:</p>
+			<pre><span>http://api.uinames.com/</span>?maxlen=75</pre>
 			<!--
 			<br />
 			<p>Results for a language within a country:</p>
@@ -112,25 +116,25 @@
 			<div><?php print number_format($available, 0, ',', '.'); ?><p>Available Names</p></div>
 		</div>
 	</div>
-	
+
 	<div id="country" class="clearfix">
 		<ul>
 			<li class="pos-0">Randomize</li>
 			<?php
-				
+
 				$newCountries = array("Japan");
 				$favCountries = array("United States");
-				
+
 				$total = count($names);
-			
+
 				for ($i = 0; $i < $total; $i++) {
 					$country = $names[$i]['country'];
-					
+
 					$new = '';
 					if (in_array($country, $newCountries)) {
 						$new = ' new';
 					}
-					
+
 					$fav = '';
 					if (in_array($country, $favCountries)) {
 						$fav = ' fav';
@@ -138,23 +142,23 @@
 							$fav = ' fav active';
 						}
 					}
-					
+
 					$oddLastFix = '';
 					if (($i + 1) == $total && $total % 2 == 0) {
 						$oddLastFix = ' oddLastFix';
 					}
-					
+
 					echo '<li class="pos-' . ($i + 1) . $new . $fav . $oddLastFix . '">' . $country . '</li>';
-					
+
 					if ($i == floor((count($names)/2) - 1)) {
 						echo '</ul><ul>';
 					}
 				}
-			
+
 			?>
 		</ul>
 	</div>
-	
+
 	<div id="options">
 		<span id="genderSelect">
 			<a class="icon random active" href="#random" title="Random Gender"><span class="r1"></span><span class="r2"></span><span class="r3"></span><span class="r4"></span><span class="r5"></span><span class="r6"></span><span class="r7"></span></a>
@@ -165,20 +169,20 @@
 			<a class="icon country" href="#country" title="Select Country"><span class="r1"></span><span class="r2"></span><span class="r3"></span><span class="r4"></span></a>
 		</span>
 	</div>
-	
+
 	<div id="details">
 		<a class="icon info" href="#info" title="More Information"><span class="i1"></span><span class="i2"></span><span class="i3"></span></a>
 	</div>
-	
+
 	<div id="share-box">
 		<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://uinames.com" data-text="Generate random names for use in designs and mockups on" data-via="thomweerd" data-count="horizontal" data-size="small" data-related="thomweerd" data-dnt="true">Tweet</a>
 		<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-		
+
 		<iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Fuinames.com&amp;width=100px&amp;layout=button_count&amp;action=like&amp;show_faces=false&amp;share=false&amp;height=65" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:85px; height:20px;" allowTransparency="true"></iframe>
-	
+
 		<iframe src="http://ghbtns.com/github-btn.html?user=thm&repo=uinames&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="84" height="20"></iframe>
 	</div>
-	
+
 	<script src="assets/js/site.js"></script>
 	<script src="assets/js/fastclick.min.js"></script>
 

--- a/uinames.com/index.php
+++ b/uinames.com/index.php
@@ -101,8 +101,10 @@
 			<br />
 			<p>Country specific results:</p>
 			<pre><span>http://api.uinames.com/</span>?country=germany</pre>
+			<br />
 			<p>Require a minimum number of characters in a name:</p>
 			<pre><span>http://api.uinames.com/</span>?minlen=25</pre>
+			<br />
 			<p>Require a maximum number of characters in a name:</p>
 			<pre><span>http://api.uinames.com/</span>?maxlen=75</pre>
 			<!--


### PR DESCRIPTION
Related to [this tweet](https://twitter.com/ErikReagan/status/587805638241189888).

I added support for two additional API parameters. We often find use in stress testing designs by using names of specific lengths. This addition allows us to require the names to be either a minimum length of characters or a maximum length of characters. 

Sample url: `http://api.uinames.com/?amount=5&minlen=40&country=Russia`

I've forked the repository for my own team's use, but thought this addition might be useful for other users of uinames.com.

Happy to make any style adjustments if the coding style isn't on par with your preferences.

Thanks!
Erik

---

P.S.: Apologies for the whitespace changes. My IDE strips whitespace on empty lines when saving files. I usually ignore those lines when committing for forked projects but forgot this go around.