### PR TITLE
fix: keyboard accessibility

### DIFF
--- a/uinames.com/assets/css/styles.css
+++ b/uinames.com/assets/css/styles.css
@@ -10,7 +10,6 @@
 	margin: 0;
 	padding: 0;
 	border: none;
-	outline: none;
 	font: inherit;
 	color: inherit;
 	vertical-align: baseline;
@@ -18,6 +17,22 @@
 	-webkit-box-sizing: border-box;
 	   -moz-box-sizing: border-box;
 	        box-sizing: border-box;
+}
+
+.mouseDetected * {
+	outline: none;
+	box-shadow: none;
+}
+
+.ac {
+	position: absolute;
+	left: -999em;
+	top: auto;
+	height: 0;
+}
+[dir=rtl] .ac {
+	left: auto;
+	right: -999em;
 }
 
 ol, ul {
@@ -86,7 +101,7 @@ p a {
 	        transition: border-bottom-color .15s ease-out;
 }
 
-p a:hover {
+p a:hover, p a:focus {
 	border-bottom-color: #222;
 }
 
@@ -100,6 +115,7 @@ pre, code {
 	font: normal 12px/150% "Droid Sans Mono", "courier new", monospace;
 	background: #f1f1f1;
 	border: 1px solid #e3e3e3;
+
 	border-radius: 2px;
 }
 
@@ -207,7 +223,7 @@ body.touch-device #help {display: none}
 	display: block;
 	position: absolute;
 	overflow: hidden;
-	
+
 	border-radius: 5px 5px 0 0;
 }
 
@@ -225,7 +241,8 @@ body.touch-device #help {display: none}
 	border-left: none;
 }
 
-#tabs > a:hover {
+#tabs > a:hover,
+#tabs > a:focus {
 	color: #999;
 }
 
@@ -238,14 +255,14 @@ body.touch-device #help {display: none}
 	cursor: default;
 }
 
-[id*="tab-"] {
+[id$="-panel"] {
 	text-align: left;
 	display: none;
 }
 
-[data-tab="info"] #tab-info,
-[data-tab="api"] #tab-api,
-[data-tab="shortcuts"] #tab-shortcuts {
+[data-tab="info"] #info-panel,
+[data-tab="api"] #api-panel,
+[data-tab="shortcuts"] #shortcuts-panel {
 	display: block;
 }
 
@@ -260,14 +277,13 @@ body.touch-device #help {display: none}
 	position: relative;
 	z-index: 4000;
 	overflow: hidden;
-	display: block;
 	
 	-webkit-transition: opacity .25s ease-out;
 	   -moz-transition: opacity .25s ease-out;
 	        transition: opacity .25s ease-out;
-	
+
 	border-radius: 5px;
-	
+
 	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.25);
 	        box-shadow: 0 1px 2px rgba(0,0,0,.25);
 }
@@ -325,6 +341,7 @@ body.touch-device #shortcuts-tab {display: none}
 	height: 100%;
 	width: 100%;
 	background: #eee;
+
 	border-radius: 50%;
 }
 
@@ -344,9 +361,9 @@ body.touch-device #shortcuts-tab {display: none}
 	visibility: hidden;
 	opacity: 0;
 	z-index: 1000;
-	
+
 	border-radius: 2px;
-	
+
 	-webkit-transition: top .25s ease-out, opacity .25s ease-out;
 	   -moz-transition: top .25s ease-out, opacity .25s ease-out;
 	        transition: top .25s ease-out, opacity .25s ease-out;
@@ -369,11 +386,11 @@ body.touch-device #shortcuts-tab {display: none}
 	background: #fff;
 	position: absolute;
 	z-index: -2;
-	
+
 	-webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, .25), 0 0 2px rgba(0,0,0,.25);
 	   -moz-box-shadow: 0 1px 2px rgba(0, 0, 0, .25), 0 0 2px rgba(0,0,0,.25);
 	        box-shadow: 0 1px 2px rgba(0, 0, 0, .25), 0 0 2px rgba(0,0,0,.25);
-	
+
 	-webkit-transform: rotate(45deg);
 	   -moz-transform: rotate(45deg);
 	        transform: rotate(45deg);
@@ -391,6 +408,7 @@ body.touch-device #shortcuts-tab {display: none}
 }
 
 .contributor:hover .popup,
+.contributor:focus .popup,
 #graph.visible .popup {
 	top: -24px;
 	visibility: visible;
@@ -411,7 +429,7 @@ body.touch-device #shortcuts-tab {display: none}
 	color: #fff;
 	background: #222;
 	overflow: hidden;
-	
+
 	border-radius: 0 0 5px 5px;
 }
 
@@ -473,7 +491,7 @@ body.touch-device #shortcuts-tab {display: none}
 	border: 1px solid #000;
 	opacity: .25;
 	position: absolute;
-	
+
 	border-radius: 50%;
 }
 
@@ -481,16 +499,12 @@ body.touch-device #shortcuts-tab {display: none}
 	height: 100%;
 	width: 100%;
 	background: #eee;
-	
+
 	border-radius: 100%;
 }
 
 #region li .region-label {
 	line-height: 260%;
-}
-
-#region li:first-child {
-	border-top: none;
 }
 
 #region li:hover {
@@ -502,9 +516,12 @@ body.touch-device #shortcuts-tab {display: none}
 }
 
 #region li:hover,
-#region li.active,
+#region li.active {
+	background-color: #f9f9f9;
+}
 #region li.highlight {
-	background: #f9f9f9;
+	color: #fff;
+	background-color: #444;
 }
 
 #region li.new:after, #region li.fav:after {
@@ -518,7 +535,7 @@ body.touch-device #shortcuts-tab {display: none}
 	color: #fff;
 	background: #161616;
 	position: absolute;
-	
+
 	border-radius: 2px;
 }
 
@@ -579,9 +596,9 @@ body.touch-device #shortcuts-tab {display: none}
 	top: 12px;
 	right: 13px;
 	background: #bbb;
-	
+
 	border-radius: 2px;
-	
+
 	position: absolute;
 }
 
@@ -589,7 +606,7 @@ body.touch-device #shortcuts-tab {display: none}
 
 #overlay {
 	opacity: 0;
-	
+
 	-webkit-transition: opacity .25s ease-out;
 	   -moz-transition: opacity .25s ease-out;
 	        transition: opacity .25s ease-out;
@@ -620,9 +637,9 @@ body.touch-device #shortcuts-tab {display: none}
 	overflow: hidden;
 	position: fixed;
 	z-index: 500;
-	
+
 	border-radius: 5px;
-	
+
 	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.25);
 	        box-shadow: 0 1px 2px rgba(0,0,0,.25);
 	
@@ -644,7 +661,7 @@ body.touch-device #shortcuts-tab {display: none}
 	position: relative;
 	display: inline-block;
 	vertical-align: top;
-	
+
 	border-radius: 3px;
 }
 
@@ -652,11 +669,11 @@ body.touch-device #shortcuts-tab {display: none}
 	padding: 3px 6px 3px 4px;
 	text-shadow: 0 -1px 0 #354c8c;
 	background: #4c69ba;
-	
+
 	background: -webkit-linear-gradient(#4c69ba, #3b55a0);
 	   background: -moz-linear-gradient(#4c69ba, #3b55a0);
 	        background: linear-gradient(#4c69ba, #3b55a0);
-	
+
 	border-radius: 2px;
 }
 
@@ -710,9 +727,9 @@ body.touch-device #shortcuts-tab {display: none}
 	margin-top: -3px;
 	background: #bbb;
 	position: absolute;
-	
+
 	border-radius: 1px;
-	
+
 	-webkit-transform: rotate(45deg);
 	   -moz-transform: rotate(45deg);
 	    -ms-transform: rotate(45deg);
@@ -734,6 +751,7 @@ body.touch-device #shortcuts-tab {display: none}
 
 #options {
 	left: 25px;
+	outline: 0;
 }
 
 #options > span:before {
@@ -744,7 +762,7 @@ body.touch-device #shortcuts-tab {display: none}
 	background: #fff;
 	opacity: .6;
 	float: left;
-	
+
 	border-radius: 5px;
 }
 
@@ -763,12 +781,14 @@ body.touch-device #shortcuts-tab {display: none}
 	border: 2px solid #fff;
 	position: relative;
 	float: left;
-	
+	background-color: transparent;
+	cursor: pointer;
+
 	border-radius: 100%;
-	
+
 	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.15);
 	        box-shadow: 0 1px 2px rgba(0,0,0,.15);
-	
+
 	-webkit-transition: opacity .15s ease-out;
 	   -moz-transition: opacity .15s ease-out;
 	        transition: opacity .15s ease-out;
@@ -782,6 +802,41 @@ body.touch-device #shortcuts-tab {display: none}
 [data-popup] #genderSelect .icon,
 [data-popup] .icon.region {
 	opacity: .6;
+}
+
+.info::-moz-focus-inner {
+  border: 0;
+}
+
+.icon:focus,
+[data-popup] #genderSelect .icon:focus,
+[data-popup] .icon.region:focus {
+	outline: 0;
+	opacity: 1;
+}
+.icon:focus {
+	box-shadow: 0 0 5px 3px #56b;
+}
+.icon:focus:after {
+	content: attr(title);
+	display: block;
+	width: 5.2em;
+	margin-top: 40px;
+	margin-left: -1em;
+	padding: 2px;
+	color: #444;
+	font-size: .7em;
+	line-height: 1;
+	background-color: #fff;
+
+	border-radius: 3px;
+}
+.mouseDetected .icon:focus  {
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.15);
+	        box-shadow: 0 1px 2px rgba(0,0,0,.15);
+}
+.mouseDetected .icon:focus:after  {
+	display: none;
 }
 
 .icon.active,
@@ -809,7 +864,7 @@ body.touch-device #shortcuts-tab {display: none}
 .icon span {
 	background: #fff;
 	position: absolute;
-	
+
 	border-radius: 5px;
 }
 
@@ -822,7 +877,7 @@ body.touch-device #shortcuts-tab {display: none}
 	left: 7px;
 	border: 2px solid #fff;
 	background: none;
-	
+
 	border-radius: 100%;
 }
 
@@ -831,7 +886,7 @@ body.touch-device #shortcuts-tab {display: none}
 	width: 2px;
 	top: 8px;
 	left: 20px;
-	
+
 	-webkit-transform: rotate(45deg);
 	    -ms-transform: rotate(45deg);
 	        transform: rotate(45deg);
@@ -860,7 +915,7 @@ body.touch-device #shortcuts-tab {display: none}
 	left: 10px;
 	border: 2px solid #fff;
 	background: none;
-	
+
 	border-radius: 100%;
 }
 
@@ -885,7 +940,7 @@ body.touch-device #shortcuts-tab {display: none}
 	width: 2px;
 	top: 10px;
 	left: 12px;
-	
+
 	-webkit-transform: rotate(-45deg);
 	    -ms-transform: rotate(-45deg);
 	        transform: rotate(-45deg);
@@ -893,7 +948,7 @@ body.touch-device #shortcuts-tab {display: none}
 
 .random .r2 {
 	left: 20px;
-	
+
 	-webkit-transform: rotate(45deg);
 	    -ms-transform: rotate(45deg);
 	        transform: rotate(45deg);
@@ -963,6 +1018,7 @@ body.touch-device #shortcuts-tab {display: none}
 
 .region .flag {
 	margin: 7px;
+	top: 0;
 	left: 0;
 	color: #000;
 	background: none !important;
@@ -975,7 +1031,7 @@ body.touch-device #shortcuts-tab {display: none}
 	width: 16px;
 	top: 11px;
 	left: 9px;
-	
+
 	-webkit-transition: top .15s ease-out .15s, opacity 0s ease-out .15s, -webkit-transform .15s ease-out;
 	   -moz-transition: top .15s ease-out .15s, opacity 0s ease-out .15s, -ms-transform .15s ease-out;
 	        transition: top .15s ease-out .15s, opacity 0s ease-out .15s, transform .15s ease-out;

--- a/uinames.com/assets/css/styles.css
+++ b/uinames.com/assets/css/styles.css
@@ -751,7 +751,6 @@ body.touch-device #shortcuts-tab {display: none}
 
 #options {
 	left: 25px;
-	outline: 0;
 }
 
 #options > span:before {

--- a/uinames.com/assets/js/site.js
+++ b/uinames.com/assets/js/site.js
@@ -115,7 +115,7 @@ function capitalize(string) {
 	function getName(e) {
 		// set parameters based on settings
 		var region = regionBox.getElementsByClassName('active')[0].getElementsByClassName('region-label')[0].innerHTML.toLowerCase().replace(/ /g, '+'),
-			gender = genders[0].parentNode.getElementsByClassName('active')[0].hash.substring(1),
+			gender = genders[0].parentNode.getElementsByClassName('active')[0].hash.substr(1),
 			bulkToggle = document.getElementById('bulk').getElementsByClassName('icon')[0];
 		
 		// function that injects all the data on the page
@@ -285,7 +285,7 @@ function capitalize(string) {
 		// reassign each time
 		trigger = this;
 
-		var name = (this.hash) ? this.hash.substring(1) : this.getAttribute('data-href'),
+		var name = (this.hash) ? this.hash.substr(1) : this.getAttribute('data-href'),
 			box = document.getElementById(name),
 			overlay = document.getElementById('overlay');
 

--- a/uinames.com/assets/js/site.js
+++ b/uinames.com/assets/js/site.js
@@ -1,17 +1,41 @@
 function addListener(li, ev, fn) {
-    var ev = ev.split(' ');
-    
-    for (var i = 0, l = ev.length; i < l; i++) {
-        if (li && window.addEventListener) {
-            li.addEventListener(ev[i], fn, false);
-        } else if (li && window.attachEvent) {
-            li.attachEvent('on' + ev[i], fn);
-        }
-    }
+	var ev = ev.split(' ');
+
+	for (var i = 0, l = ev.length; i < l; i++) {
+		if (li && window.addEventListener) {
+			li.addEventListener(ev[i], fn, false);
+		} else if (li && window.attachEvent) {
+			li.attachEvent('on' + ev[i], fn);
+		}
+	}
 }
 
 function hasClass(elem, klass) {
-     return (' ' + elem.className + ' ').indexOf(' ' + klass + ' ') > -1;
+	return (' ' + elem.className + ' ').indexOf(' ' + klass + ' ') > -1;
+}
+function addClass(elem,klass) {
+	if (!hasClass(elem, klass)) {
+		elem.className += (elem.className==='') ? klass : (' '+klass);
+	}
+}
+function removeClass(elem, klass) {
+	if (hasClass(elem, klass)) {
+		var pattern = new RegExp('(^| )' + klass + '( |$)');
+		elem.className = elem.className.replace(pattern,'$1').replace(/ $/,'');
+	}
+}
+
+function clearClasses(array, length, class_string) {
+	while (length--) {
+		removeClass(array[length], class_string);
+	}
+}
+
+function setAttribute(array, length, attribute, class_string) {
+	while (length--) {
+		var value = hasClass(array[length], class_string);
+		array[length].setAttribute(attribute, value);
+	}
 }
 
 function capitalize(string) {
@@ -19,39 +43,59 @@ function capitalize(string) {
 }
 
 (function() {
-	
+
 	var body = document.getElementsByTagName('body')[0],
 		nameContainer = document.getElementById('name'),
+		destination = document.getElementById('destination'),
 		genders = document.getElementById('genderSelect').getElementsByTagName('a'),
 		infoToggle = document.getElementsByClassName('info')[0],
 		regionSelect = document.getElementsByClassName('icon region')[0],
 		regionBox = document.getElementById('region'),
+		searchInput = region.getElementsByTagName('input')[0],
 		availableRegions = regionBox.getElementsByTagName('li'),
 		infoBox = document.getElementById('info');
-	
+
+	// so we don't tab into invisible things
+	infoBox.style.display = 'none';
+	regionBox.style.display = 'none';
+
+	// MOUSE DETECTION
+	// www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+	addListener(body, 'mousedown keydown', function(e) {
+		return (e.type == 'mousedown') ?
+				addClass(body,'mouseDetected') :
+				removeClass(body,'mouseDetected');
+      });
+
 	// REGION SWITCHER
-	function regionToggle() {
-		for (var j = 0; j < availableRegions.length; j++) {
-			availableRegions[j].className = availableRegions[j].className.replace(/\b ?active\b/g, '');
-		}
-		this.className += ' active';
+	function regionToggle(elem) {
+		var l = availableRegions.length,
+			current = (elem.nodeType==1) ? elem : this;
+
+		clearClasses(availableRegions, l, 'active');
+		addClass(current, 'active');
 		
 		// switch to new region
-		localStorage.setItem('region', this.getElementsByClassName('region-label')[0].innerHTML);
+		var regionName = current.getElementsByClassName('region-label')[0].innerHTML,
+			b = regionSelect.getElementsByTagName('b')[0];
+		localStorage.setItem('region', regionName);
 		
 		// update the flag in the region icon
-		regionSelect.getElementsByTagName('img')[0].src = this.getElementsByTagName('img')[0].src;
+		regionSelect.getElementsByTagName('img')[0].src = current.getElementsByTagName('img')[0].src;
+
+		// update the textual name in the region icon
+		b.innerHTML = regionName + ' selected';
 		
 		// wait 250ms so the user can see the region switched
 		setTimeout(function() {
-			body.removeAttribute('data-popup');
+			closePopup();
 		}, 250);
 	}
 	
 	for (var i = 0; i < availableRegions.length; i++) {
 		addListener(availableRegions[i], 'click', regionToggle);
 	}
-	
+
 	// select region from local storage if saved
 	var storedRegion = localStorage.getItem('region');
 	if (storedRegion) {
@@ -71,7 +115,7 @@ function capitalize(string) {
 	function getName(e) {
 		// set parameters based on settings
 		var region = regionBox.getElementsByClassName('active')[0].getElementsByClassName('region-label')[0].innerHTML.toLowerCase().replace(/ /g, '+'),
-			gender = genders[0].parentNode.getElementsByClassName('active')[0].hash.substr(1),
+			gender = genders[0].parentNode.getElementsByClassName('active')[0].hash.substring(1),
 			bulkToggle = document.getElementById('bulk').getElementsByClassName('icon')[0];
 		
 		// function that injects all the data on the page
@@ -90,56 +134,56 @@ function capitalize(string) {
 				nameContainer.innerHTML = '';
 				
 				if (!hasClass(body, 'bulk')) {
-					body.className += ' bulk';
+					addClass(body, 'bulk');
 				}
 				
 				// inject names, genders and regions into page
 				for (var i = 0; i < namesRequested; i++) {
 					nameContainer.innerHTML += '<h1>' + data[i]['name'] + ' ' + data[i]['surname'] + '</h1><p>' + capitalize(data[i]['gender']) + ' from ' + data[i]['region'] + '</p>';
 				}
-				
+
 				// pause requests to stop overly excited users
-				body.className += ' bulkPause';
-				
+				addClass(body, 'bulkPause');
+
 				// bulk toggle count-down
 				var bulkCache = bulkToggle.innerHTML,
 					count = 11;
-				
+
 				var interval = setInterval(function() {
 					bulkToggle.innerHTML = count - 1;
 					bulkToggle.style.lineHeight = '200%';
 					if (count <= 0 || !hasClass(bulkToggle, 'active')) {
 						bulkToggle.innerHTML = bulkCache;
-						body.className = body.className.replace(/\b ?bulkPause\b/g, '');
+						removeClass(body, 'bulkPause');
 						bulkToggle.style.lineHeight = '';
 						clearInterval(interval);
 					}
 					count--;
 				}, 600);
-				
+
 				// reset name node and count
 				namesRequested = maxNamesRequested;
 			} else {
-				body.className = body.className.replace(/\b ?bulk\b/g, '');
+				removeClass(body, 'bulk');
 			}
-			
+
 			nameContainer.style.display = '';
-			
+
 			// surface help elements
 			specs.style.display = '';
 			help.style.display = '';
 			help.className = 'animate';
-			
+
 			setTimeout(function() {
 				help.className = '';
 			}, 250);
-			
+
 			// count generated name
 			var getJSON = new XMLHttpRequest();
 			getJSON.open('POST', 'api/counter.php', true);
 			getJSON.send();
 		}
-		
+
 		function injectNewData() {
 			// get new names from api
 			var getJSON = new XMLHttpRequest();
@@ -149,64 +193,87 @@ function capitalize(string) {
 					injectData(data, 0);
 				}
 			};
-			
+
 			// send the request
 			getJSON.open('GET', 'api/?amount=' + maxNamesRequested + '&region=' + region + '&gender=' + gender, true);
 			getJSON.send();
-			
+
 			// reset counter
 			namesRequested = 0;
 		}
-		
+
 		// detect end of road or a change in settings
 		if (namesRequested == 0 || namesRequested >= maxNamesRequested || oldRegion != region || oldGender != gender || hasClass(bulkToggle, 'active')) {
 			injectNewData();
 		} else {
 			injectData(data, namesRequested);
 		}
-		
+
 		// update flags
 		namesRequested++;
 		oldRegion = region;
 		oldGender = gender;
 	}
-	
+
 	// GENDER TOGGLE
 	function toggleGender(e) {
-	    e.preventDefault();
-	    e.stopPropagation();
-	
-        if (!hasClass(this, 'active')) {
-            for (var i = 0; i < genders.length; i++) {
-                genders[i].className = genders[i].className.replace(/\b ?active\b/g, '');
-            }
-            this.className += ' active';
-        }
-    }
+		e.preventDefault();
+		e.stopPropagation();
+
+		if (!hasClass(this, 'active')) {
+			var l = genders.length;
+			clearClasses(genders, l, 'active');
+			addClass(this, 'active');
+			setAttribute(genders, l, 'aria-pressed', 'active');
+		}
+	}
     
-    for (var i = 0; i < genders.length; i++) {
-    	addListener(genders[i], 'click', toggleGender);
-    }
-	
+	for (var i = 0; i < genders.length; i++) {
+		addListener(genders[i], 'click', toggleGender);
+	}
+
 	// BULK TOGGLE
 	var bulk = document.getElementById('bulk').getElementsByClassName('icon bulk')[0];
-	
+
 	function toggleBulk(e) {
-	    e.preventDefault();
-	    e.stopPropagation();
-	
-        if (hasClass(bulk, 'active')) {
-            bulk.className = bulk.className.replace(/\b ?active\b/g, '');
+		e.preventDefault();
+		e.stopPropagation();
+
+		if (hasClass(bulk, 'active')) {
+			removeClass(bulk, 'active');
 		} else {
-            bulk.className += ' active';
-        }
-    }
+			addClass(bulk, 'active');
+		}
+		bulk.setAttribute('aria-pressed', hasClass(bulk, 'active'));
+	}
     
 	addListener(bulk, 'click', toggleBulk);
-    	
+
+
+	// whoever opens popups, to get the focus when they're closed
+	var trigger;
+
 	// POPUP CLOSER
 	function closePopup() {
-		regionBox.getElementsByTagName('input')[0].blur();
+		var name = body.getAttribute('data-popup'),
+			popup = document.getElementById(name);
+
+		if (name == 'region') {
+			regionBox.getElementsByTagName('input')[0].blur();
+			destination.focus();
+			searchInput.removeEventListener('keyup', search);
+		}
+		// no popup onload
+		// prevent tabbing through invisibles
+		if (popup) {
+			popup.style.display = 'none';
+		}
+		// no trigger onload
+		// prevent hocus-focus
+		if (trigger) {
+			trigger.focus();
+		}
+
 		body.removeAttribute('data-popup');
 	}
 	
@@ -214,15 +281,19 @@ function capitalize(string) {
 	function togglePopup(e) {
 		e.preventDefault();
 		e.stopPropagation();
-		
-		var hash = this.hash.substr(1),
+
+		// reassign each time
+		trigger = this;
+
+		var name = (this.hash) ? this.hash.substring(1) : this.getAttribute('data-href'),
+			box = document.getElementById(name),
 			overlay = document.getElementById('overlay');
 
-		if (body.getAttribute('data-popup') == hash) {
+		if (body.getAttribute('data-popup') == name) {
 			closePopup();
 		} else {
 			// lazy load images
-			var lazyImages = document.getElementById(hash).getElementsByClassName('lazy');
+			var lazyImages = document.getElementById(name).getElementsByClassName('lazy');
 			for (var i = 0; i < lazyImages.length; i++) {
 				(function(i) {
 					setTimeout(function() {
@@ -230,73 +301,169 @@ function capitalize(string) {
 					}, i*15);
 				})(i);
 			}
-			
+
+			// stopPropagation isn't really the right tool
+			// sometimes still passes on to search input which now
+			// listens to 'Enter'. So this nasty hack instead.
+			if (name == 'region') {
+				setTimeout(function() {
+					addListener(searchInput, 'keyup', search);
+				}, 150);
+			}
+
+			// let transitions work
+			box.style.display = 'block';
+
 			// show popup
-			body.setAttribute('data-popup', hash);
+			setTimeout(function() {
+				body.setAttribute('data-popup', name);
+			}, 50);
 			
 			// let's focus the input field if it's the region popup
-			if (hash == 'region') {
+			if (name == 'region') {
 				regionBox.getElementsByTagName('input')[0].focus();
 			}
 		}
-		
+
 		addListener(overlay, 'click', closePopup);
-		
+
 	}
 	
 	addListener(infoToggle, 'click', togglePopup);
 	addListener(regionSelect, 'click', togglePopup);
-	
+
 	// INFO TABS TOGGLE
 	var tabs = document.getElementById('tabs').getElementsByTagName('a');
-	
+
 	function toggleTab(e) {
-	    e.preventDefault();
-	    e.stopPropagation();
-	    
-		body.setAttribute('data-tab', this.hash.substr(1));
-    }
+		e.preventDefault();
+		e.stopPropagation();
+
+		body.setAttribute('data-tab', this.getAttribute('data-set'));
+
+		// let non-visual users know which tab is selected
+		for (var i = 0; i < tabs.length; i++) {
+			var tab = tabs[i],
+				b = tab.getElementsByTagName('b')[0];
+
+			b.innerHTML = '';
+			if (tab == this) {
+				b.innerHTML = '(Selected)';
+			}
+		}
+	}
     
-    for (var i = 0; i < tabs.length; i++) {
-    	addListener(tabs[i], 'click', toggleTab);
-    }
-    
-    // REGION SEARCH
-    var regions = regionBox.getElementsByTagName('li'),
-    	searchInput = document.getElementsByTagName('input')[0],
-    	regionCount = regionBox.getElementsByClassName('regionCount')[0],
-    	contribute = regionBox.getElementsByClassName('contribute')[0];
-    
-    function search(e) {
-    	var regionMatches = regions.length;
-    	
-    	for (var i = 0; i < regions.length; i++) {
-    		var region = regions[i],
-    			regionValue = region.getElementsByClassName('region-label')[0].innerHTML.toLowerCase();
-    		
-    		if (regionValue.indexOf(searchInput.value.toLowerCase(), 0) == 0) {
-    			region.className = region.className.replace(/\b ?inactive\b/g, '');
-    			regionMatches = regionMatches + 1;
-    		} else {
-    			if (!hasClass(region, 'inactive')) {
-	    			region.className += ' inactive';
-	    		}
-    			regionMatches = regionMatches - 1;
-    		}
-    	}
-    	
+	for (var i = 0; i < tabs.length; i++) {
+		addListener(tabs[i], 'click', toggleTab);
+	}
+
+	// REGION SEARCH
+	var regions = regionBox.getElementsByTagName('li'),
+		regionCount = regionBox.getElementsByClassName('regionCount')[0],
+		contribute = regionBox.getElementsByClassName('contribute')[0];
+
+	// navigates options
+	function comboNav(k, currentMatches) {
+		var current, // array position
+			length = currentMatches.length;
+
+		for (var i = 0; i < length; i++) {
+			var r = currentMatches[i];
+			if (hasClass(r, 'highlight')) {
+				current = i;
+				break;
+			}
+		}
+		if (current == undefined) {
+			addClass(currentMatches[0], 'highlight');
+			current = 0;
+			return;
+		}
+
+		function sallyForth() {
+			current = (current !== (length - 1)) ? (current + 1) : 0;
+			clearClasses(currentMatches, length, 'highlight');
+			addClass(currentMatches[current], 'highlight');
+		}
+
+		function fallBack() {
+			current = (current !== 0) ? (current - 1) : (length - 1);
+			clearClasses(currentMatches, length, 'highlight');
+			addClass(currentMatches[current], 'highlight');
+		}
+
+		if (length > 1) {
+			switch (k) {
+				case 36:
+					clearClasses(currentMatches, length, 'highlight');
+					addClass(currentMatches[0], 'highlight');
+					current = 0;
+					break;
+				case 35:
+					clearClasses(currentMatches, length, 'highlight');
+					addClass(currentMatches[length-1], 'highlight');
+					current = length; 
+					break;
+				case 38:
+					fallBack();
+					break;
+				case 40:
+					sallyForth();
+					break;
+				default:
+					break;
+			}
+		}
+
+		searchInput.setAttribute('aria-activedescendant', currentMatches[current].id);
+
+		if (k == 13) {
+			regionToggle(document.getElementById(currentMatches[current].id));
+		}
+	}
+
+	function search(e) {
+		var k = e.which,
+			regionMatches = regions.length;
+
+		for (var i = 0, l = regions.length; i < l; i++) {
+			var region = regions[i],
+				regionValue = region.getElementsByClassName('region-label')[0].innerHTML.toLowerCase();
+			
+			if (regionValue.indexOf(searchInput.value.toLowerCase(), 0) == 0) {
+				removeClass(region, 'inactive');
+				regionMatches = regionMatches + 1;
+			} else {
+				if (!hasClass(region, 'inactive')) {
+					addClass(region, 'inactive');
+				}
+				regionMatches = regionMatches - 1;
+			}
+		}
+
 		regionCount.innerHTML = regionMatches / 2 + '/' + regions.length;
-		
+
 		if (regionMatches == 0) {
 			contribute.style.display = '';
 		} else {
 			contribute.style.display = 'none';
 		}
-    }
-    
-    addListener(searchInput, 'keyup', search);
-    
-    // SHORTCUTS
+
+		if (k == 35 || k == 36|| 
+			k == 38 || k == 40 || k == 13) {
+			var currentMatches = [];
+
+			for (var i = 0, l = regions.length; i < l; i++) {
+				var r = regions[i];
+				if (!hasClass(r, 'inactive')) {
+					currentMatches.push(r);
+				}
+			}
+			return comboNav(k, currentMatches);
+		}
+	}
+
+	// SHORTCUTS
 	addListener(window, 'keyup touchstart', function(e) {
 		var num = e.which || e.keyCode || e.type == 'touchstart' || 0;
 		
@@ -353,7 +520,7 @@ function capitalize(string) {
 	});
 
 })();
-	
+
 // STALKING CODE
 var _gaq = _gaq || [];
 _gaq.push(['_setAccount', 'UA-46677803-1']);

--- a/uinames.com/index.php
+++ b/uinames.com/index.php
@@ -15,7 +15,7 @@
 
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
 <head>
 
 	<meta charset="utf-8" />
@@ -76,17 +76,46 @@
 		}
 	</script>
 
-	<div id="name"><h1><em><script>document.write(action)</script></em></h1></div>
+	<div id="name" aria-live="polite" aria-atomic="true"><h1><em><script>document.write(action)</script></em></h1></div>
 	<p id="specs" style="display: none"></p>
 	<p id="help" style="display: none">Press <span>C</span> to select, then <span><script>document.write(c)</script></span> to copy!</p>
 	
+	<p class="ac" id="destination" tabindex="-1">In options menu</p>
+	<div id="options">
+		<span id="genderSelect">
+			<a role="button" class="icon random active" href="#random" title="Gender: Random" aria-label="Gender: Random" aria-pressed="true">
+				<span class="r1"></span><span class="r2"></span><span class="r3"></span><span class="r4"></span><span class="r5"></span><span class="r6"></span><span class="r7"></span>
+			</a>
+			<a role="button" class="icon male" href="#male" title="Gender: Male" aria-label="Gender: Male" aria-pressed="false">
+				<span class="m1"></span><span class="m2"></span><span class="m3"></span><span class="m4"></span>
+			</a>
+			<a role="button" class="icon female" href="#female" title="Gender: Female" aria-label="Gender: Female" aria-pressed="false">
+				<span class="f1"></span><span class="f2"></span><span class="f3"></span>
+			</a>
+		</span>
+		<span id="regionSelect">
+			<a class="icon region active" href="#region" title="Select Region">
+				<span class="flag"><img src="assets/img/flags/random.gif" /></span>
+				<b class="ac">Random region selected</b>
+			</a>
+		</span>
+		<span id="bulk">
+			<a role="button" class="icon bulk" href="#bulk" title="Bulk mode" aria-label="Bulk mode" aria-pressed="false">
+				<span class="b1"></span><span class="b2"></span><span class="b3"></span>
+			</a>
+		</span>
+	</div>
+	
+	<div id="details">
+		<button type="button" class="icon info" data-href="info" title="More Information" aria-label="More Information"><span class="i1"></span><span class="i2"></span><span class="i3"></span><span class="i4"></span></button>
+	</div>
 	<div id="info" class="clearfix">
 		<div id="tabs">
-			<a id="info-tab" href="#info">Info</a>
-			<a id="api-tab" href="#api">API</a>
-			<a id="shortcuts-tab" href="#shortcuts">Shortcuts</a>
+			<a id="info-tab" href="#info-panel" data-set="info">Info <b class="ac">(Selected)</b></a>
+			<a id="api-tab" href="#api-panel" data-set="api">API <b class="ac"></b></a>
+			<a id="shortcuts-tab" href="shortcuts-panel" data-set="shortcuts">Shortcuts <b class="ac"></b></a>
 		</div>
-		<div id="tab-info">
+		<div id="info-panel">
 			<h2>About</h2>
 			<p><a href="http://uinames.com">uinames.com</a> is a simple tool to generate names for use in designs and mockups. Made by <a href="http://twitter.com/thomweerd" target="_blank">Thom</a>.</p>
 			<h2>Elsewhere</h2>
@@ -110,7 +139,7 @@
 			</p>
 			<p>Check out <a href="http://uifaces.com" target="_blank">uifaces.com</a> as well!</p>
 		</div>
-		<div id="tab-api">
+		<div id="api-panel">
 			<h2>Overview</h2>
 			<p>All responses are returned as JSON(P). There is currently no request limit. However, please keep the amount of requests to a minimum, and cache responses whenever possible.</p>
 			<h2>Usage</h2>
@@ -145,7 +174,7 @@
 			<p>Error messages have the following format:</p>
 			<pre>{"error":"Region or language not found"}</pre>
 		</div>
-		<div id="tab-shortcuts">
+		<div id="shortcuts-panel">
 			<h2>Names</h2>
 			<p><code>Spacebar</code> to generate a new name</p>
 			<p><code>C</code> to highlight the current name</p>
@@ -167,10 +196,13 @@
 	</div>
 
 	<div id="region" class="clearfix">
-		<ul>
-			<span class="regionCount"><?php echo (count($names) + 1) . '/' . (count($names) + 1); ?></span>
-			<input class="search" type="text" placeholder="Type to search..." />
-			<li class="pos-0"><span class="flag"><img src="assets/img/flags/random.gif" /></span><span class="region-label">Random</span></li>
+		<div>
+			<label for="rsearch" id="regionSearchLabel" class="ac">Search regions</label>
+			<span class="regionCount" aria-live="polite" aria-atomic="true"><?php echo (count($names) + 1) . '/' . (count($names) + 1); ?></span>
+			<input class="search" type="text" placeholder="Type to search..." role="combobox" aria-expanded="true" aria-autocomplete="list" id="rsearch" aria-labelledby="regionSearchLabel" aria-owns="regionList" aria-activedescendant="region-0" />
+		</div>
+		<ul id="regionList" role="listbox">
+			<li id="region-0" class="pos-0" role="option" tabindex="-1"><span class="flag"><img src="assets/img/flags/random.gif" /></span><span class="region-label">Random</span></li>
 			<?php
 				
 				$newRegions = array("Slovakia");
@@ -194,7 +226,7 @@
 						}
 					}
 					
-					echo '<li class="pos-' . ($i + 1) . $new . $fav . '"><span class="flag"><img class="lazy" src="assets/img/blank.png" data-src="assets/img/flags/' . str_replace(' ', '-', strtolower($region)) . '.png" /></span><span class="region-label">' . $region . '</span></li>';
+					echo '<li id="region-' . ($i + 1) . '" class="pos-' . ($i + 1) . $new . $fav . '" role="option" tabindex="-1"><span class="flag"><img class="lazy" src="assets/img/blank.png" data-src="assets/img/flags/' . str_replace(' ', '-', strtolower($region)) . '.png" /></span><span class="region-label">' . $region . '</span></li>';
 				}
 				
 			?>
@@ -209,23 +241,6 @@
 	
 	<div id="overlay"></div>
 	
-	<div id="options">
-		<span id="genderSelect">
-			<a class="icon random active" href="#random" title="Gender: Random"><span class="r1"></span><span class="r2"></span><span class="r3"></span><span class="r4"></span><span class="r5"></span><span class="r6"></span><span class="r7"></span></a>
-			<a class="icon male" href="#male" title="Gender: Male"><span class="m1"></span><span class="m2"></span><span class="m3"></span><span class="m4"></span></a>
-			<a class="icon female" href="#female" title="Gender: Female"><span class="f1"></span><span class="f2"></span><span class="f3"></span></a>
-		</span>
-		<span id="regionSelect">
-			<a class="icon region active" href="#region" title="Select Region"><span class="flag"><img src="assets/img/flags/random.gif" /></span></a>
-		</span>
-		<span id="bulk">
-			<a class="icon bulk" href="#bulk" title="Bulk mode"><span class="b1"></span><span class="b2"></span><span class="b3"></span></a>
-		</span>
-	</div>
-	
-	<div id="details">
-		<a class="icon info" href="#info" title="More Information"><span class="i1"></span><span class="i2"></span><span class="i3"></span><span class="i4"></span></a>
-	</div>
 	
 	<div id="share-box">
 		<iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Fuinames.com&amp;width=100px&amp;layout=button_count&amp;action=like&amp;show_faces=false&amp;share=false&amp;height=65" scrolling="no" frameborder="0" style="border:none; overflow: hidden; width: 87px; height: 20px;" allowTransparency="true"></iframe>


### PR DESCRIPTION
1. Added lang attribute

2. Rearranged HTML so the options come first, then the tabbed interface, then the region selector

3. Replaced outline: none on links with mouse/keyboard detection and show a shadow and title text as popup on :focus. Others may want to tweak the visual design of this. I also did this with the github names/links: the contributors' names appear on :hover, so I added them to show as well on :focus

4. Controversial: Since the "links" (which normally would be buttons) have two "states", I gave some of these links a role of "button" in order to have the handy aria-pressed state. However since hitting spacebar while being focussed on a button would prevent the name script from running, I've left them links. This does mean it's now the wrong role for the element, or that people who believe it's a button won't get the interaction expected (space triggering it).
   If the method to generate a new name ever changes to some other key, these would be better off becoming actual, real buttons. This would be the preferred solution.
   Or, they could be left as links and have no confusing role="button" and instead hidden text could reflect the "state" of the link. This would be a less-preferred solution since these links still don't act like links and don't take people anywhere

5. Added a label for the search input. Gave the search input a role of combobox and the list underneath a role of listbox; keyboard listeners now listen for Home, End, up/down arrows, and the Enter key. 
   The enter key event was somehow getting over to the search input when Enter triggered the region link... I hacked in a setTimeout to stop the popup from immediately closing again. This isn't ideal, but I couldn't see why the event was moving over to the other element.
   This whole setup doesn't necessarily work with screen readers currently, but at least it works with plain keyboard. Screen readers *are* reading out the selected names as they are arrowed

6. Managed focus: when something is triggered open, closing that thing moves focus back to the trigger, with one exception

7. Made the id's of the "panels" match the "tab" links' hrefs. Controversial: I did not turn the "tabs" and "panels" into an actual <a href="https://www.w3.org/TR/wai-aria-practices/#tabpanel">Tab Panel</a>, mostly because more keyboarders still expect to be able to Tab from "tab" to "tab" and only the first "panel" has focusables inside it. Instead, I add the hidden text "(Selected)" in the visible tab's name.
   If someone else thinks this should be a real tab panel, it probably also needs text for keyboarders to appear with instructions on how these work

8. Added a few extra helper functions. Initially because I use them for the mouse detection, which then didn't make sense to not use it where classes were being added/removed in the original code

9. Hidden things are now display: none

Notes:
1. I noticed while testing that on my Dell laptop with Windows 7 (64-bit), Internet Explorer 11 seems to make the page think it's a touchscreen.
2. Screen readers who switch "modes" tend not to work on this page anyway, since pressing "spacebar" on a page is often hijacked by the screen reader for its own uses. Users can work around this with key combos to force the following keypress to be passed on to the browser, but in general I don't consider this PR as making things work for screen reader users, just sighted keyboarders, even though there's a bunch of aria-junk in here.
3. Didn't fix color contrast issues.
