### PR TITLE
Fix resulting names when first name has spaces

### DIFF
--- a/uinames.com/api/index.php
+++ b/uinames.com/api/index.php
@@ -167,7 +167,7 @@ function generate_name($database, $region = ANY, $language = ANY, $gender = ANY)
 
 	// this works 99.7% of the time, maybe
 	$chunks	     = explode(' ', $subject);
-	$name_chunks = array_splice($chunks, 0, $name_chunk_count - 1);
+	$name_chunks = array_splice($chunks, 0, $name_chunk_count + 1);
 	$name		 = implode(' ', $name_chunks);
 	$surname	 = implode(' ', $chunks);
 


### PR DESCRIPTION
When the (first) name of generated output has spaces, the result is invalid.

Here's an example:
{"name":"","surname":"María Carmen Rodríguez","gender":"female","region":"Spain"}

The name (which was originally 'María Carmen') is empty and instead put into the surname. 

Other examples that currently break:
Name: "A B", Surname: "C"
Current: Name: "", Surname: "A B C"

Name: "A B C", Surname: "D"
Current: Name: "A", Surname: "B C D"

Name: "A B C", Surname: "D E"
Current: Name: "A", Surname: "B C D E"



