### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/uinames.com/api/index.php
+++ b/uinames.com/api/index.php
@@ -6,7 +6,7 @@
 // ini_set('display_errors', DEBUGGING ? 'On' : 'Off');
 // if (!DEBUGGING) ob_start();
 
-const ANY = NULL;
+const ANY = null;
 
 function sanitize($database) {
 	static $defaultValues = [


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!