### PR TITLE
removing spaces from emails in Dutch names

### DIFF
--- a/uinames.com/api/index.php
+++ b/uinames.com/api/index.php
@@ -88,7 +88,7 @@ function generate_ext_result($result) {
 	} else {
 		$email = strtolower($name . $separation[rand(0,3)] . $surname);
 	}
-	$result['email'] = "$email@example.com";
+	$result['email'] = str_replace(" ", $separation[rand(0,3)], $email) . "@example.com";
 	
 	// password
 	$signs = ['!','@','#','$','%','^','&','*','(',')','{','}','~','+','=','_',''];


### PR DESCRIPTION
because dutch names have "Name Von Surname" or "Name de Surname" it causes emails to have spaces. Not critical, but nice to be able to pass email standard verification.